### PR TITLE
fix: use default github.token for PR creation

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -36,7 +36,6 @@ jobs:
 
       - uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GH_PAT }}
           commit-message: 'chore: apply formatting'
           branch: chore/auto-format
           title: 'chore: apply formatting'


### PR DESCRIPTION
Made-with: Cursor